### PR TITLE
Set larger receive buffer size for bulk requests

### DIFF
--- a/agentx/network.py
+++ b/agentx/network.py
@@ -97,7 +97,7 @@ class Network():
         self.socket.send(pdu.encode())
 
     def recv_pdu(self):
-        buf = self.socket.recv(1024)
+        buf = self.socket.recv(8192)
         if not buf: return None
         pdu = PDU()
         pdu.decode(buf)


### PR DESCRIPTION
When using SNMP BULK GET requests (from Zabbix in our case), the default value of 1024 truncates the request, resulting in malformed requests reaching the agent. Using an 8K buffer fixes this. A better approach perhaps would be to process the buffer using a loop.